### PR TITLE
Fix typedef name collision w/MSVC compilers

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -223,7 +223,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.2.4)
+    rexml (3.2.5)
     rouge (3.26.0)
     ruby-enum (0.9.0)
       i18n

--- a/src/draco/core/cycle_timer.cc
+++ b/src/draco/core/cycle_timer.cc
@@ -17,31 +17,31 @@
 namespace draco {
 void DracoTimer::Start() {
 #ifdef _WIN32
-  QueryPerformanceCounter(&tv_start);
+  QueryPerformanceCounter(&tv_start_);
 #else
-  gettimeofday(&tv_start, nullptr);
+  gettimeofday(&tv_start_, nullptr);
 #endif
 }
 
 void DracoTimer::Stop() {
 #ifdef _WIN32
-  QueryPerformanceCounter(&tv_end);
+  QueryPerformanceCounter(&tv_end_);
 #else
-  gettimeofday(&tv_end, nullptr);
+  gettimeofday(&tv_end_, nullptr);
 #endif
 }
 
 int64_t DracoTimer::GetInMs() {
 #ifdef _WIN32
   LARGE_INTEGER elapsed = {0};
-  elapsed.QuadPart = tv_end.QuadPart - tv_start.QuadPart;
+  elapsed.QuadPart = tv_end_.QuadPart - tv_start_.QuadPart;
 
   LARGE_INTEGER frequency = {0};
   QueryPerformanceFrequency(&frequency);
   return elapsed.QuadPart * 1000 / frequency.QuadPart;
 #else
-  const int64_t seconds = (tv_end.tv_sec - tv_start.tv_sec) * 1000;
-  const int64_t milliseconds = (tv_end.tv_usec - tv_start.tv_usec) / 1000;
+  const int64_t seconds = (tv_end_.tv_sec - tv_start_.tv_sec) * 1000;
+  const int64_t milliseconds = (tv_end_.tv_usec - tv_start_.tv_usec) / 1000;
   return seconds + milliseconds;
 #endif
 }

--- a/src/draco/core/cycle_timer.h
+++ b/src/draco/core/cycle_timer.h
@@ -20,9 +20,10 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
-typedef LARGE_INTEGER timeval;
+typedef LARGE_INTEGER DracoTimeVal;
 #else
 #include <sys/time.h>
+typedef timeval DracoTimeVal;
 #endif
 
 #include <cinttypes>
@@ -39,8 +40,8 @@ class DracoTimer {
   int64_t GetInMs();
 
  private:
-  timeval tv_start;
-  timeval tv_end;
+  DracoTimeVal tv_start_;
+  DracoTimeVal tv_end_;
 };
 
 typedef DracoTimer CycleTimer;

--- a/src/draco/io/parser_utils.cc
+++ b/src/draco/io/parser_utils.cc
@@ -18,6 +18,7 @@
 #include <cctype>
 #include <cmath>
 #include <iterator>
+#include <limits>
 
 namespace draco {
 namespace parser {


### PR DESCRIPTION
Fix typedef name collision w/MSVC compilers